### PR TITLE
Add OpenCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Both modes require explicit invocation in their trigger instructions; ordinary c
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/openclaw.svg" width="32" alt="OpenClaw"><br><sub>OpenClaw</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/claude.svg" width="32" alt="Claude"><br><sub>Claude Code</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/codex.svg" width="32" alt="Codex"><br><sub>Codex</sub></td>
+    <td align="center"><img src="https://opencode.ai/favicon.svg" width="32" alt="OpenCode"><br><sub>OpenCode</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/bash.svg" width="32" alt="Bash"><br><sub>Bash</sub></td>
     <td align="center"><img src="https://cdn.simpleicons.org/githubcopilot/8957E5" width="32" alt="GitHub Copilot"><br><sub>GitHub Copilot CLI</sub></td>
   </tr>
@@ -132,6 +133,14 @@ openclaw plugins install hubo --marketplace h0ngcha0/hubo
 
 Restart the OpenClaw gateway after installing.
 
+### OpenCode
+
+```bash
+npx skills add h0ngcha0/hubo --skill hubo hubo-review --agent opencode -g -y
+```
+
+Start a new OpenCode session after installing.
+
 ### skills.sh (optional standalone install)
 
 Install both Hubo skills directly into any supported host:
@@ -154,6 +163,7 @@ npx skills add h0ngcha0/hubo --skill hubo hubo-review -g
 
 - **Claude Code or GitHub Copilot CLI:** `/hubo` and `/hubo-review`.
 - **Codex:** `$hubo` and `$hubo-review`.
+- **OpenCode:** `/hubo` and `/hubo-review`; use `/skills` to open the skill picker.
 - **OpenClaw:** `/skill hubo` and `/skill hubo-review`.
 
 For example:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,6 +84,7 @@ Hubo 提供两种需要显式调用的模式：
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/openclaw.svg" width="32" alt="OpenClaw"><br><sub>OpenClaw</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/claude.svg" width="32" alt="Claude"><br><sub>Claude Code</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/codex.svg" width="32" alt="Codex"><br><sub>Codex</sub></td>
+    <td align="center"><img src="https://opencode.ai/favicon.svg" width="32" alt="OpenCode"><br><sub>OpenCode</sub></td>
     <td align="center"><img src="https://raw.githubusercontent.com/paperclipai/paperclip/d1b9448b57a8cfb0e8dbede9bbbc8874a9f66ad7/doc/assets/logos/bash.svg" width="32" alt="Bash"><br><sub>Bash</sub></td>
     <td align="center"><img src="https://cdn.simpleicons.org/githubcopilot/8957E5" width="32" alt="GitHub Copilot"><br><sub>GitHub Copilot CLI</sub></td>
   </tr>
@@ -132,6 +133,14 @@ openclaw plugins install hubo --marketplace h0ngcha0/hubo
 
 安装后重启 OpenClaw gateway。
 
+### OpenCode
+
+```bash
+npx skills add h0ngcha0/hubo --skill hubo hubo-review --agent opencode -g -y
+```
+
+安装后开始一个新的 OpenCode 会话。
+
 ### skills.sh（可选的独立安装）
 
 把 Hubo 的两个技能直接安装到任一受支持的宿主：
@@ -154,6 +163,7 @@ npx skills add h0ngcha0/hubo --skill hubo hubo-review -g
 
 - **Claude Code 或 GitHub Copilot CLI：** `/hubo` 和 `/hubo-review`。
 - **Codex：** `$hubo` 和 `$hubo-review`。
+- **OpenCode：** `/hubo` 和 `/hubo-review`；使用 `/skills` 打开技能选择器。
 - **OpenClaw：** `/skill hubo` 和 `/skill hubo-review`。
 
 例如：

--- a/skills/hubo-review/SKILL.md
+++ b/skills/hubo-review/SKILL.md
@@ -18,6 +18,7 @@ Use the first available host:
 - Codex: create with `spawn_agent`, resume with `followup_task`, and wait with `wait_agent`.
 - Claude Code: create with `Agent`, resume with `SendMessage`, and consume completion notifications.
 - GitHub Copilot CLI: create background roles with `task`, resume with `write_agent`, and consume completion notifications or `read_agent`.
+- OpenCode: create the critic standby first, then the main reviewer, as foreground `general` tasks; record each returned task ID and resume the same child with `task_id`.
 - OpenClaw: create kept sessions with `sessions_spawn`, resume with `sessions_send`, and wait with `sessions_yield`.
 
 Create each role once and reuse its ID for every round. The critic's initial task returns only `READY`. Optional descendants inherit their parent's read-only boundary. If the host cannot create and resume two addressable roles, ask whether the user accepts a sequential single-agent fallback.

--- a/skills/hubo/references/hosts.md
+++ b/skills/hubo/references/hosts.md
@@ -47,6 +47,21 @@ Select this adapter when `task`, `list_agents`, `read_agent`, and `write_agent` 
 
 Keep both background agents alive for the multi-turn reconciliation loop. Resolve their IDs from the initial `task` results or `list_agents`; use `write_agent` for every later round.
 
+## OpenCode
+
+Select this adapter when `task` is available and accepts `task_id` to resume a prior child session.
+
+| Hubo action | OpenCode mapping |
+| --- | --- |
+| Create roles | Call `task` twice with the `general` subagent type and the two role names required by the invoking skill as their descriptions. Create the standby role first, then the active role, and record each returned task ID. |
+| Standby | Prompt the mode-designated standby role to return `READY` without inspecting files. The completed child session remains resumable by task ID. |
+| Resume a role | Call `task` with the recorded `task_id` and the same subagent type; never create a replacement child for a new round. |
+| Wait | Prefer foreground tasks, whose completed result returns directly. If experimental background tasks are enabled, consume their automatic completion messages; do not poll. |
+| Relay | Mirror every complete top-level role report in the current OpenCode conversation with its mode-defined role and round label; repeat it in the final conversation transcript, never a file. |
+| Descendants | Permit them only when that child exposes `task`; otherwise keep bounded subwork in the owning top-level role. |
+
+OpenCode's default `general` subagent is not mechanically read-only. Enforce the review lineage's protocol boundary and compare content-sensitive worktree evidence before and after every review turn.
+
 ## OpenClaw
 
 Select this adapter when `sessions_spawn`, `sessions_send`, and `sessions_yield` are available.


### PR DESCRIPTION
## Summary

- add an OpenCode host adapter using resumable `task_id` sessions
- document OpenCode installation and explicit activation in English and Chinese
- add OpenCode to the supported-host table

## Why

OpenCode already discovers Agent Skills and supports resumable `task` subagents, but Hubo did not map those capabilities or provide an installation path.

## Impact

OpenCode users can install both Hubo modes with `skills.sh`, invoke `/hubo` or `/hubo-review`, and keep the same implementer/reviewer sessions across reconciliation rounds.

## Validation

- installed both skills into an isolated OpenCode project with `skills.sh`
- verified `opencode debug skill --pure` discovers `hubo` and `hubo-review`
- verified installed reference files include the OpenCode adapter
- ran `git diff --check`
- validated all plugin manifests with `jq empty`

Closes #2
